### PR TITLE
PR: fix/reset-field-uses-updated-initial-values

### DIFF
--- a/src/lib/form.svelte.ts
+++ b/src/lib/form.svelte.ts
@@ -393,7 +393,7 @@ export function useFormControl<T>(props: FormControlProps<T>) {
 		},
 
 		resetField(path: FlatPaths<T>) {
-			setByPath(form.data, path, getValueByPath(initialValues, path));
+			setByPath(form.data, path, getValueByPath(form.initialValues, path));
 			form.touched[path] = false;
 			form.dirty[path] = false;
 		},


### PR DESCRIPTION
## Summary

Fix resetField() using stale initialValues after setInitialValues().

## Changes

- Use form.initialValues instead of closure initialValues
- Ensure resetField() respects updated initial values

Closes #13